### PR TITLE
refine.initialise is not required

### DIFF
--- a/gap/BacktrackKit.gi
+++ b/gap/BacktrackKit.gi
@@ -123,8 +123,6 @@ BTKit_InitialiseConstraints := function(state, tracer, rbase)
             if not BTKit_ApplyFilters(state.ps, tracer, filters) then
                 return false;
             fi;
-        else
-            ErrorNoReturn("constraint <c> has no refine.initialise member,");
         fi;
     od;
     return true;

--- a/gap/constraint.gd
+++ b/gap/constraint.gd
@@ -37,7 +37,7 @@
 #! arguments are described with the relevant function, below.
 #!
 #TODO: the return value of <C>initialise</C> seems to be important.
-#! * <C>initialise</C> <E>(required)</E>. This is called when search begins.
+#! * <C>initialise</C> - This is called when search begins.
 #!   Note that, since the <C>refine.initialise</C> function is called for all
 #!   relevant constraints at the beginning of search, the partition may have
 #!   already been split by some earlier constraint by the time that
@@ -47,7 +47,7 @@
 #! * <C>changed</C> - One or splits occurred.
 #!
 #TODO: this is unclear. Also unimplemented.
-#! * <C>rBaseFinished</C> - The rBase has been created (is passed the rbase).
+#! * <C>rBaseFinished</C> - The rBase has been created (is passed the rBase).
 #!   Constraints which care about this can use this to remember the rBase
 #!   construction is finished.
 


### PR DESCRIPTION
@ChrisJefferson this PR is more of a pull-question than a pull-request.

I was looking through your `build-more` branch (https://github.com/ChrisJefferson/BacktrackKit/branches). It seems that everything there made its way into the `master` branch, except for some documentation changes to `constraint.gd`.

In particular, you changed the documentation to say that the `refine.initialise` component of a constraint was not required (https://github.com/ChrisJefferson/BacktrackKit/commit/7b1122c859e365da770882f7b71c1972949c4249#diff-d3eab6ad5699cc94dbc95596de905dc8). In the code, at that point, it wasn't. However, at some point since then, I added an `ErrorNoReturn` in `BacktrackKit.gi` that's called if a constraint doesn't have such a component. The only reason I had for this was that the documentation said it was required, I didn't have a mathematical reason. And since you wrote code deleting the requirement, it seems that maybe you thought it shouldn't be there.

So: should `refine.initialise` be required, or not?